### PR TITLE
Changed UserAgent. Changed GetStaticHandler() to use bot.Client.Do() …

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -901,7 +901,11 @@ func GetStaticHandler(c echo.Context) error {
 	bot := c.Get("bot").(*OGame)
 
 	newURL := bot.serverURL + c.Request().URL.String()
-	resp, err := http.Get(newURL)
+	req, err := http.NewRequest("HEAD", newURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := bot.Client.Do(req)
 	if err != nil {
 		bot.error(err)
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -901,7 +901,7 @@ func GetStaticHandler(c echo.Context) error {
 	bot := c.Get("bot").(*OGame)
 
 	newURL := bot.serverURL + c.Request().URL.String()
-	req, err := http.NewRequest("HEAD", newURL, nil)
+	req, err := http.NewRequest("GET", newURL, nil)
 	if err != nil {
 		return err
 	}

--- a/ogame.go
+++ b/ogame.go
@@ -127,9 +127,9 @@ type Preferences struct {
 }
 
 const defaultUserAgent = "" +
-	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) " +
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64)  " +
 	"AppleWebKit/537.36 (KHTML, like Gecko) " +
-	"Chrome/79.0.3945.130 " +
+	"Chrome/80.0.3987.132 " +
 	"Safari/537.36"
 
 type options struct {


### PR DESCRIPTION
Two changes:

1) Changed UserAgent. 
2) Changed GetStaticHandler() to use bot.Client.Do() with the correct User-Agent instead of using raw HTTP.Get() which sends wrong User-Agent.