### PR TITLE
Fix: DoAuctionHandler : call ParseForm() before using PostForm

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1121,6 +1121,9 @@ func GetAuctionHandler(c echo.Context) error {
 func DoAuctionHandler(c echo.Context) error {
 	bot := c.Get("bot").(*OGame)
 	bid := make(map[CelestialID]Resources)
+	if err := c.Request().ParseForm(); err != nil { // Required for PostForm, not for PostFormValue
+		return c.JSON(http.StatusBadRequest, ErrorResp(400, "invalid form"))
+	}
 	for key, values := range c.Request().PostForm {
 		for _, s := range values {
 			var metal, crystal, deuterium int64


### PR DESCRIPTION
Call c.Request().ParseForm() to populate c.Request().PostForm or it will remain empty and bids cannot be made