### PR TITLE
fix: techs endpoint missing parameter

### DIFF
--- a/cmd/ogamed/main.go
+++ b/cmd/ogamed/main.go
@@ -317,7 +317,7 @@ func start(c *cli.Context) error {
 	e.POST("/bot/planets/:planetID/send-ipm", ogame.SendIPMHandler)
 	e.GET("/bot/moons/:moonID/phalanx/:galaxy/:system/:position", ogame.PhalanxHandler)
 	e.POST("/bot/moons/:moonID/jump-gate", ogame.JumpGateHandler)
-	e.GET("/bot/techs", ogame.TechsHandler)
+	e.GET("/bot/techs/:celestialID", ogame.TechsHandler)
 	e.GET("/game/allianceInfo.php", ogame.GetAlliancePageContentHandler) // Example: //game/allianceInfo.php?allianceId=500127
 
 	// Get/Post Page Content


### PR DESCRIPTION
Fixes the `/bot/tech` endpoint, which was missing the URL parameter `:celestialID`