### PR TITLE
* fixed new Browser /assets/css/*

### DIFF
--- a/cmd/ogamed/main.go
+++ b/cmd/ogamed/main.go
@@ -332,6 +332,7 @@ func start(c *cli.Context) error {
 	// For AntiGame plugin
 	// Static content
 	e.GET("/cdn/*", ogame.GetStaticHandler)
+	e.GET("/assets/css/*", ogame.GetStaticHandler)
 	e.GET("/headerCache/*", ogame.GetStaticHandler)
 	e.GET("/favicon.ico", ogame.GetStaticHandler)
 	e.GET("/game/sw.js", ogame.GetStaticHandler)


### PR DESCRIPTION
fix for OGame Browser Proxy 
* added /assets/css/* route in ogamed Service.

This should fix the Resources Bar on top of the OGame Page