### PR TITLE
Login Handler improvement to try reuse cookies before use Login() function

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -99,7 +99,7 @@ func PageContentHandler(c echo.Context) error {
 // LoginHandler ...
 func LoginHandler(c echo.Context) error {
 	bot := c.Get("bot").(*OGame)
-	if err := bot.Login(); err != nil {
+	if err := bot.LoginWithExistingCookies(); err != nil {
 		if err == ErrBadCredentials {
 			return c.JSON(http.StatusBadRequest, ErrorResp(400, err.Error()))
 		}

--- a/handlers.go
+++ b/handlers.go
@@ -99,7 +99,7 @@ func PageContentHandler(c echo.Context) error {
 // LoginHandler ...
 func LoginHandler(c echo.Context) error {
 	bot := c.Get("bot").(*OGame)
-	if err := bot.LoginWithExistingCookies(); err != nil {
+	if _, err := bot.LoginWithExistingCookies(); err != nil {
 		if err == ErrBadCredentials {
 			return c.JSON(http.StatusBadRequest, ErrorResp(400, err.Error()))
 		}


### PR DESCRIPTION
This helps by Login problems if you start ogamed Service with parameters --auto-login=false and then use /bot/login to login. This handler didn't try to use cookies, so it could happen that you have to solve a captcha first. This little fix should help here.