### PR TITLE
Fix ACS detection bug

### DIFF
--- a/pkg/wrapper/ogame.go
+++ b/pkg/wrapper/ogame.go
@@ -1728,8 +1728,8 @@ func (b *OGame) fetchEventbox() (res eventboxResp, err error) {
 }
 
 func (b *OGame) isUnderAttack() (bool, error) {
-	res, err := b.fetchEventbox()
-	return res.Hostile > 0, err
+	attacks, err := b.getAttacks()
+	return len(attacks) > 0, err
 }
 
 func (b *OGame) setVacationMode() error {


### PR DESCRIPTION
acs attacks where the defender is invited to the party are not detected by isUnderAttack(), as they are not counterd as hostile in the eventBox
i fixed it by counting getAttacks(), as the method already contains the fix