### PR TITLE
fix for minimum Speed Function in ShipsInfos.Speed() function

### DIFF
--- a/pkg/ogame/ships.go
+++ b/pkg/ogame/ships.go
@@ -1,8 +1,9 @@
 package ogame
 
 import (
-	"github.com/alaingilbert/ogame/pkg/utils"
 	"math"
+
+	"github.com/alaingilbert/ogame/pkg/utils"
 )
 
 // ShipsInfos represent a planet ships information
@@ -69,7 +70,7 @@ func (s ShipsInfos) HasFlyableShips() bool {
 func (s ShipsInfos) Speed(techs Researches, isCollector, isGeneral bool) int64 {
 	var minSpeed int64 = math.MaxInt64
 	for _, ship := range Ships {
-		if ship.GetID() == SolarSatelliteID {
+		if ship.GetID() == SolarSatelliteID || ship.GetID() == CrawlerID {
 			continue
 		}
 		nbr := s.ByID(ship.GetID())


### PR DESCRIPTION
* fix for minimum Speed in ships.Speed() function
  - ignore SolarSatelliteID and CrawlerID

If Crawler is > 0 it Speed function always returns 0 because Craweler have no Speed Set or its 0.