### PR TITLE
fix OGame logout function - Does not really logout!

### DIFF
--- a/pkg/wrapper/fetcher.go
+++ b/pkg/wrapper/fetcher.go
@@ -66,7 +66,7 @@ const (
 
 func (b *OGame) getPage(page string, opts ...Option) ([]byte, error) {
 	vals := url.Values{"page": {"ingame"}, "component": {page}}
-	if page == FetchResourcesPageName || page == FetchTechsName {
+	if page == FetchResourcesPageName || page == FetchTechsName || page == LogoutPageName {
 		vals = url.Values{"page": {page}}
 	}
 	return b.getPageContent(vals, opts...)


### PR DESCRIPTION
Logout function actually produce Query Parameters "?page=ingame&component=logout" which doesn't logout from Ogame!

Fix this by using  "?page=logout".

So I modified "getPage" Function in pkg/wrapper/fetcher.go.

It is useful to logout and relogin with existing cookies to prevent full login. Actaully using it for LoginEvent.