### PR TITLE
fix for Vacation detection due Universe Merges event

### DIFF
--- a/pkg/extractor/v6/extracts.go
+++ b/pkg/extractor/v6/extracts.go
@@ -35,16 +35,20 @@ func extractTearDownButtonEnabledFromDoc(doc *goquery.Document) bool {
 }
 
 func extractIsInVacationFromDoc(doc *goquery.Document) bool {
-	href := doc.Find("div#advice-bar a").AttrOr("href", "")
-	if href == "" {
-		return false
-	}
-	u, _ := url.Parse(href)
-	q := u.Query()
-	if q.Get("page") == "preferences" && q.Get("selectedTab") == "3" && q.Get("openGroup") == "0" {
-		return true
-	}
-	return false
+	var isVacation bool
+	doc.Find("div#advice-bar a").Each(func(i int, s *goquery.Selection) {
+		href := s.AttrOr("href", "")
+		if href == "" {
+			return
+		}
+		u, _ := url.Parse(href)
+		q := u.Query()
+		if q.Get("page") == "preferences" && q.Get("selectedTab") == "3" && q.Get("openGroup") == "0" {
+			isVacation = true
+			return
+		}
+	})
+	return isVacation
 }
 
 func extractResourcesFromDoc(doc *goquery.Document) ogame.Resources {

--- a/pkg/extractor/v8/extracts.go
+++ b/pkg/extractor/v8/extracts.go
@@ -2,27 +2,32 @@ package v8
 
 import (
 	"errors"
-	"github.com/PuerkitoBio/goquery"
-	v71 "github.com/alaingilbert/ogame/pkg/extractor/v71"
-	"github.com/alaingilbert/ogame/pkg/ogame"
-	"github.com/alaingilbert/ogame/pkg/utils"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	v71 "github.com/alaingilbert/ogame/pkg/extractor/v71"
+	"github.com/alaingilbert/ogame/pkg/ogame"
+	"github.com/alaingilbert/ogame/pkg/utils"
 )
 
 func extractIsInVacationFromDoc(doc *goquery.Document) bool {
-	href := doc.Find("div#advice-bar a").AttrOr("href", "")
-	if href == "" {
-		return false
-	}
-	u, _ := url.Parse(href)
-	q := u.Query()
-	if q.Get("component") == "preferences" && q.Get("selectedTab") == "3" && q.Get("openGroup") == "0" {
-		return true
-	}
-	return false
+	var isVacation bool
+	doc.Find("div#advice-bar a").Each(func(i int, s *goquery.Selection) {
+		href := s.AttrOr("href", "")
+		if href == "" {
+			return
+		}
+		u, _ := url.Parse(href)
+		q := u.Query()
+		if q.Get("component") == "preferences" && q.Get("selectedTab") == "3" && q.Get("openGroup") == "0" {
+			isVacation = true
+			return
+		}
+	})
+	return isVacation
 }
 
 func extractEspionageReportFromDoc(doc *goquery.Document, location *time.Location) (ogame.EspionageReport, error) {


### PR DESCRIPTION
I noticed that **IsVacationModeEnabled()** not returning the correct value,

The implementation will now iterate over all a-hrefs in the #advice-bar section, to find the Vacation Mode criteria.