### PR TITLE
optimize replaceHostname with Regxp

### DIFF
--- a/cmd/ogamed/main.go
+++ b/cmd/ogamed/main.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"crypto/subtle"
+	"log"
+	"os"
+	"strconv"
+
 	"github.com/alaingilbert/ogame/pkg/device"
 	"github.com/alaingilbert/ogame/pkg/wrapper"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"gopkg.in/urfave/cli.v2"
-	"log"
-	"os"
-	"strconv"
 )
 
 var version = "0.0.0"
@@ -106,8 +107,8 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:    "api-new-hostname",
-			Usage:   "New OGame Hostname eg: https://someuniverse.example.com",
-			Value:   "http://127.0.0.1:8080",
+			Usage:   "New OGame Hostname eg: http://127.0.0.1:8080 or https://someuniverse.example.com",
+			Value:   "",
 			EnvVars: []string{"OGAMED_NEW_HOSTNAME"},
 		},
 		&cli.StringFlag{

--- a/pkg/wrapper/handlers.go
+++ b/pkg/wrapper/handlers.go
@@ -1,12 +1,12 @@
 package wrapper
 
 import (
-	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/alaingilbert/ogame/pkg/ogame"
@@ -1013,17 +1013,24 @@ func GetAlliancePageContentHandler(c echo.Context) error {
 	return c.HTML(http.StatusOK, string(pageHTML))
 }
 
-func replaceHostname(bot *OGame, html []byte) []byte {
-	serverURLBytes := []byte(bot.serverURL)
-	apiNewHostnameBytes := []byte(bot.apiNewHostname)
-	escapedServerURL := bytes.Replace(serverURLBytes, []byte("/"), []byte(`\/`), -1)
-	doubleEscapedServerURL := bytes.Replace(serverURLBytes, []byte("/"), []byte("\\\\\\/"), -1)
-	escapedAPINewHostname := bytes.Replace(apiNewHostnameBytes, []byte("/"), []byte(`\/`), -1)
-	doubleEscapedAPINewHostname := bytes.Replace(apiNewHostnameBytes, []byte("/"), []byte("\\\\\\/"), -1)
-	html = bytes.Replace(html, serverURLBytes, apiNewHostnameBytes, -1)
-	html = bytes.Replace(html, escapedServerURL, escapedAPINewHostname, -1)
-	html = bytes.Replace(html, doubleEscapedServerURL, doubleEscapedAPINewHostname, -1)
-	return html
+func replaceHostnameWithRegxp(bot *OGame, pageHTML []byte, r *http.Request) []byte {
+	requestHostname := "http://" + r.Host
+	if r.TLS != nil {
+		requestHostname = "https://" + r.Host
+	}
+	regexes := []string{
+		`https://s\d+-[a-z]{2}\.ogame\.gameforge\.com`,
+		`https?:\\/\\/s\d+-[a-z]{2}\.ogame\.gameforge\.com`,
+		`https?:\\\\/\\\\/s\d+-[a-z]{2}\.ogame\.gameforge\.com`,
+	}
+	for _, regex := range regexes {
+		if bot.apiNewHostname != "" {
+			pageHTML = regexp.MustCompile(regex).ReplaceAll(pageHTML, []byte(bot.apiNewHostname))
+		} else {
+			pageHTML = regexp.MustCompile(regex).ReplaceAll(pageHTML, []byte(requestHostname))
+		}
+	}
+	return pageHTML
 }
 
 // GetStaticHandler ...
@@ -1041,7 +1048,7 @@ func GetStaticHandler(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, ErrorResp(500, err.Error()))
 	}
 	defer resp.Body.Close()
-	body, err := utils.ReadBody(resp)
+	pageHTML, err := utils.ReadBody(resp)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResp(500, err.Error()))
 	}
@@ -1057,11 +1064,11 @@ func GetStaticHandler(c echo.Context) error {
 	}
 
 	if strings.Contains(c.Request().URL.String(), ".xml") {
-		body = replaceHostname(bot, body)
-		return c.Blob(http.StatusOK, "application/xml", body)
+		pageHTML = replaceHostnameWithRegxp(bot, pageHTML, c.Request())
+		return c.Blob(http.StatusOK, "application/xml", pageHTML)
 	}
 
-	contentType := http.DetectContentType(body)
+	contentType := http.DetectContentType(pageHTML)
 	if strings.Contains(newURL, ".css") {
 		contentType = "text/css"
 	} else if strings.Contains(newURL, ".js") {
@@ -1070,7 +1077,7 @@ func GetStaticHandler(c echo.Context) error {
 		contentType = "image/gif"
 	}
 
-	return c.Blob(http.StatusOK, contentType, body)
+	return c.Blob(http.StatusOK, contentType, pageHTML)
 }
 
 // GetFromGameHandler ...
@@ -1081,7 +1088,7 @@ func GetFromGameHandler(c echo.Context) error {
 		vals = c.QueryParams()
 	}
 	pageHTML, _ := bot.GetPageContent(vals)
-	pageHTML = replaceHostname(bot, pageHTML)
+	pageHTML = replaceHostnameWithRegxp(bot, pageHTML, c.Request())
 	return c.HTMLBlob(http.StatusOK, pageHTML)
 }
 
@@ -1094,7 +1101,7 @@ func PostToGameHandler(c echo.Context) error {
 	}
 	payload, _ := c.FormParams()
 	pageHTML, _ := bot.PostPageContent(vals, payload)
-	pageHTML = replaceHostname(bot, pageHTML)
+	pageHTML = replaceHostnameWithRegxp(bot, pageHTML, c.Request())
 	return c.HTMLBlob(http.StatusOK, pageHTML)
 }
 


### PR DESCRIPTION
Set --api-new-hostname empty by default.

replaceHostnameWithRegxp will use the hostname which is set by --api-new-hostname parameter, but if it is empty string it will lookup the Hostname from the Request Header!

This makes it possible to access the Browser Endpoint "/game/index.php" from localhost, domain or even IP-Address.