### PR TITLE
ogamed-service /bot/check-fleet endpoint

### DIFF
--- a/cmd/ogamed/main.go
+++ b/cmd/ogamed/main.go
@@ -339,6 +339,7 @@ func start(ctx context.Context, c *cli.Command) error {
 	e.POST("/bot/planets/:planetID/cancel-building", wrapper.CancelBuildingHandler)
 	e.POST("/bot/planets/:planetID/cancel-research", wrapper.CancelResearchHandler)
 	e.GET("/bot/planets/:planetID/resources", wrapper.GetResourcesHandler)
+	e.POST("/bot/planets/:planetID/check-fleet", wrapper.CheckFleetHandler)
 	e.POST("/bot/planets/:planetID/send-fleet", wrapper.SendFleetHandler)
 	e.POST("/bot/planets/:planetID/send-discovery", wrapper.SendDiscoveryHandler)
 	e.POST("/bot/planets/:planetID/send-ipm", wrapper.SendIPMHandler)


### PR DESCRIPTION
added planet endpoint to get fleet-cargo, -capacity, fuel-consumption and flight-duration

Example:
curl 127.0.0.1:8080/bot/planets/123/send-fleet -d 'ships=202,1&speed=1&galaxy=1&system=384&position=5&type=1&mission=4&metal=1&crystal=2&deuterium=3'

```
{
  "Status": "ok",
  "Code": 200,
  "Message": "",
  "Result": {
    "origin": {
      "Galaxy": 1,
      "System": 384,
      "Position": 4,
      "Type": 1
    },
    "destination": {
      "Galaxy": 1,
      "System": 384,
      "Position": 5,
      "Type": 1
    },
    "flightTime": 19619,
    "fuel": 2,
    "resources": {
      "Metal": 1,
      "Crystal": 2,
      "Deuterium": 3,
      "Energy": 0,
      "Darkmatter": 0,
      "Population": 0,
      "Food": 0
    },
    "cargo": 5750,
    "cargoUsed": 6,
    "ships": {
      "LightFighter": 0,
      "HeavyFighter": 0,
      "Cruiser": 0,
      "Battleship": 0,
      "Battlecruiser": 0,
      "Bomber": 0,
      "Destroyer": 0,
      "Deathstar": 0,
      "SmallCargo": 1,
      "LargeCargo": 0,
      "ColonyShip": 0,
      "Recycler": 0,
      "EspionageProbe": 0,
      "SolarSatellite": 0,
      "Crawler": 0,
      "Reaper": 0,
      "Pathfinder": 0
    },
    "mission": 4,
    "speed": 1
  }
}
```
